### PR TITLE
Define commands for fullstop and comma in math mode

### DIFF
--- a/include/cmds.tex
+++ b/include/cmds.tex
@@ -84,3 +84,7 @@
 \newcommand{\cre}{c^\dagger}                          % annihalation operator
 \newcommand{\anh}{c^{\vphantom{\dagger}}}             % creation operator
 \newcommand{\numb}{n^{\vphantom{\dagger}}}            % number operator
+
+\newcommand{\fullstop}{\text{\,.}}                    % fullstop or comma in
+\newcommand{\comma}{\text{\,,}}                       % math mode for use
+                                                      % after equations


### PR DESCRIPTION
Whenever I use an environment like align or equation in the middle or at the end of a sentence, I like to use those commands to type a comma or full stop easier.
