### PR TITLE
Include directories chap and fig to the graphicspath

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -81,6 +81,10 @@
 }
 
 
+% To include graphics from the following directories it will be sufficient
+% to use the filename; no need to indicate the relative path from the main
+% directory. Add more directories if you like.
+\graphicspath{{./chap/}{./fig/}}
 
 
 


### PR DESCRIPTION
Make it easier to include graphics (I don't know if this is also possible for tables). This way, it's sufficient to write \includegraphics{fig.pdf} without the chap/ or fig/ in front.
