### PR TITLE
Fix iss #13: incompatibility of svg and subcaption

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compile on the command line using <code>make main.pdf</code> or your favorite La
 * <code>pdflatex main.tex</code>
 * <code>pdflatex main.tex</code>
 
-The template is known to be compatible with TeXLive 2012 and 2014.
+The template is known to be compatible with TeX Live 2012, 2014, and 2016.
 
 ## Contribute to the template
 

--- a/include/thesisclass.cls
+++ b/include/thesisclass.cls
@@ -97,6 +97,7 @@
                                                 % definitions
 
 \usepackage[pdftex]{graphicx}                   % including images
+
 \usepackage[normal,
                 font={small,color=black},
                 labelfont=bf,
@@ -144,13 +145,9 @@
             linkbordercolor=kitcolor,
             citebordercolor=kitcolor]{hyperref}
 
-\expandafter\def\csname ver@subfig.sty\endcsname{}
-                                                % stop package svg from loading 
-                                                % package subfig
-                                                % http://tex.stackexchange.com/\
-                                                % questions/213273/undefined-  \
-                                                % control-sequence-            \
-                                                % at-begindocument
+\RequirePackage{scrlfile}                       % Prevent svg (<2.0) package 
+\PreventPackageFromLoading{subfig}              % from loading subfig.
+                                                % See also iss. #13
 \usepackage{svg}                                % include svg graphics
 
 \graphicspath{{./chap/}{./fig/}}                % To include graphics from the 


### PR DESCRIPTION
As discussed in
https://tex.stackexchange.com/questions/291929/svg-package-and-subcaption-incompability/338390#338390
TeX Live >2015 does not handle the hack to prevent loading subfig from within svg correct, but this new solution does.
The svg package >=2.0 does not depend on subfig any more anyway.

Until now I only tested it on a tainted Fedora 27 (TeX Live 2016) and not in Docker nor on any other system or TeX Live version.
Someone may also test this patch on the computer pool, please. I cannot do it, because my account is not working anymore.