### PR TITLE
Ändere 'Ansichtsexemplar' in 'Prüfungsexemplar'

### DIFF
--- a/include/preamble.tex
+++ b/include/preamble.tex
@@ -20,7 +20,7 @@ gültigen Fassung vom 27.11.2014 beachtet habe.\\
 \vfill
 
 \begin{flushright}
-	Als Ansichtsexemplar genehmigt von\\
+	Als Prüfungsexemplar genehmigt von\\
 	\vspace{1cm}
 	\begin{tabular}{rr}
 		Karlsruhe, den \thesistimehandin, & \hspace*{5cm}\\[0mm]


### PR DESCRIPTION
Es wurde angemerkt, dass man ein Prüfungsexemplar abgeben muss, was den rechtlichen Unterschied macht, dass nur eine Version des Prüfungsexemplars existieren darf. Ein Ansichtsexemplar kann in unterschiedlichen Versionen vorliegen.