### PR TITLE
Fix spelling error on titlepage

### DIFF
--- a/include/titlepage.tex
+++ b/include/titlepage.tex
@@ -84,7 +84,7 @@
         \begin{tabular}[ht]{l c l}
         \iflanguage{english}{Reviewer}{Referent}: 
             & \hfill & \thesisreviewerone\\
-        \iflanguage{english}{Second Reviewer}{Korreferent}: 
+        \iflanguage{english}{Second Reviewer}{Koreferent}: 
             & \hfill & \thesisreviewertwo\\
         % uncomment if you want to provide info on your advisors
         %\iflanguage{english}{Advisor}{Betreuender Mitarbeiter}: 


### PR DESCRIPTION
"Koreferent" has only one "r", see https://www.duden.de/rechtschreibung/Koreferat